### PR TITLE
Add support for referencing sub-scenes

### DIFF
--- a/projects/pbr_viewer/pbr_viewer.cpp
+++ b/projects/pbr_viewer/pbr_viewer.cpp
@@ -81,7 +81,7 @@ void PBRViewer::setup()
     create_graphics_pipeline();
 
     // load a scene
-    build_scene(m_scene_data.nodes.empty() ? load_scene_data() : m_scene_data);
+    build_scene(m_scene_data.nodes.empty() ? load_scene_data() : m_scene_data, true);
 }
 
 void PBRViewer::teardown()

--- a/projects/pbr_viewer/pbr_viewer.hpp
+++ b/projects/pbr_viewer/pbr_viewer.hpp
@@ -106,7 +106,7 @@ public:
         //! list of child-nodes (indices into scene_data_t::nodes)
         std::vector<uint32_t> children = {};
 
-        //! optional mesh-index and set of enabled entries.
+        //! optional index into an array of sub-scenes.
         std::optional<size_t> scene_index;
 
         //! optional mesh-index and set of enabled entries.

--- a/projects/pbr_viewer/pbr_viewer.hpp
+++ b/projects/pbr_viewer/pbr_viewer.hpp
@@ -107,6 +107,9 @@ public:
         std::vector<uint32_t> children = {};
 
         //! optional mesh-index and set of enabled entries.
+        std::optional<size_t> scene_index;
+
+        //! optional mesh-index and set of enabled entries.
         std::optional<size_t> mesh_index;
         std::optional<std::unordered_set<uint32_t>> entry_indices = {};
 
@@ -126,7 +129,12 @@ public:
 
     struct scene_data_t
     {
+        //! array of file-paths, containing sub-scenes (.json)
+        std::vector<std::string> scene_paths;
+
+        //! array of file-paths, containing model-files (.gltf, .glb, .obj)
         std::vector<std::string> model_paths;
+
         std::string environment_path;
         std::vector<scene_node_t> nodes;
 
@@ -310,11 +318,12 @@ template<class Archive>
 void serialize(Archive &ar, PBRViewer::scene_node_t &scene_node)
 {
     ar(cereal::make_nvp("name", scene_node.name), cereal::make_optional_nvp("enabled", scene_node.enabled, true),
-       cereal::make_nvp("transform", scene_node.transform), cereal::make_nvp("children", scene_node.children),
-       cereal::make_nvp("mesh_index", scene_node.mesh_index),
-       cereal::make_nvp("entry_indices", scene_node.entry_indices),
-       cereal::make_nvp("animation_state", scene_node.animation_state),
-       cereal::make_nvp("physics_state", scene_node.physics_state));
+       cereal::make_nvp("transform", scene_node.transform), cereal::make_optional_nvp("children", scene_node.children),
+       cereal::make_optional_nvp("scene_index", scene_node.scene_index),
+       cereal::make_optional_nvp("mesh_index", scene_node.mesh_index),
+       cereal::make_optional_nvp("entry_indices", scene_node.entry_indices),
+       cereal::make_optional_nvp("animation_state", scene_node.animation_state),
+       cereal::make_optional_nvp("physics_state", scene_node.physics_state));
 }
 
 template<class Archive>
@@ -327,8 +336,9 @@ void serialize(Archive &ar, PBRViewer::scene_camera_t &camera)
 template<class Archive>
 void serialize(Archive &ar, PBRViewer::scene_data_t &scene_data)
 {
-    ar(cereal::make_nvp("environment_path", scene_data.environment_path),
+    ar(cereal::make_optional_nvp("environment_path", scene_data.environment_path),
+       cereal::make_optional_nvp("scene_paths", scene_data.scene_paths),
        cereal::make_nvp("model_paths", scene_data.model_paths), cereal::make_nvp("nodes", scene_data.nodes),
        cereal::make_nvp("scene_roots", scene_data.scene_roots), cereal::make_nvp("cameras", scene_data.cameras),
-       cereal::make_nvp("materials", scene_data.materials));
+       cereal::make_optional_nvp("materials", scene_data.materials));
 }

--- a/projects/pbr_viewer/pbr_viewer.hpp
+++ b/projects/pbr_viewer/pbr_viewer.hpp
@@ -197,7 +197,7 @@ private:
 
     static std::optional<scene_data_t> load_scene_data(const std::filesystem::path &path = "scene.json");
 
-    void build_scene(const std::optional<scene_data_t> &scene_data, bool import = false);
+    void build_scene(const std::optional<scene_data_t> &scene_data, bool import = false, SceneId scene_id = {});
 
     struct overlay_assets_t
     {

--- a/projects/pbr_viewer/pbr_viewer.hpp
+++ b/projects/pbr_viewer/pbr_viewer.hpp
@@ -16,6 +16,8 @@
 #include <vierkant/physics_context.hpp>
 #include <vierkant/physics_debug_draw.hpp>
 
+DEFINE_NAMED_UUID(SceneId)
+
 class PBRViewer : public crocore::Application
 {
 
@@ -106,8 +108,8 @@ public:
         //! list of child-nodes (indices into scene_data_t::nodes)
         std::vector<uint32_t> children = {};
 
-        //! optional index into an array of sub-scenes.
-        std::optional<size_t> scene_index;
+        //! optional sub-scene-id.
+        std::optional<SceneId> scene_id;
 
         //! optional mesh-index and set of enabled entries.
         std::optional<size_t> mesh_index;
@@ -133,7 +135,8 @@ public:
         std::string name;
 
         //! array of file-paths, containing sub-scenes (.json)
-        std::vector<std::string> scene_paths;
+        // std::vector<std::string> scene_paths;
+        std::unordered_map<SceneId, std::string> scene_paths;
 
         //! array of file-paths, containing model-files (.gltf, .glb, .obj)
         std::vector<std::string> model_paths;
@@ -284,6 +287,7 @@ private:
 
     // tmp, keep track of mesh/model-paths
     std::map<vierkant::MeshConstPtr, std::filesystem::path> m_model_paths;
+    std::map<SceneId, std::filesystem::path> m_scene_paths;
 };
 
 template<class Archive>
@@ -322,7 +326,7 @@ void serialize(Archive &ar, PBRViewer::scene_node_t &scene_node)
 {
     ar(cereal::make_nvp("name", scene_node.name), cereal::make_optional_nvp("enabled", scene_node.enabled, true),
        cereal::make_nvp("transform", scene_node.transform), cereal::make_optional_nvp("children", scene_node.children),
-       cereal::make_optional_nvp("scene_index", scene_node.scene_index),
+       cereal::make_optional_nvp("scene_id", scene_node.scene_id),
        cereal::make_optional_nvp("mesh_index", scene_node.mesh_index),
        cereal::make_optional_nvp("entry_indices", scene_node.entry_indices),
        cereal::make_optional_nvp("animation_state", scene_node.animation_state),

--- a/projects/pbr_viewer/pbr_viewer.hpp
+++ b/projects/pbr_viewer/pbr_viewer.hpp
@@ -134,8 +134,7 @@ public:
         //! descriptive name for the scene
         std::string name;
 
-        //! array of file-paths, containing sub-scenes (.json)
-        // std::vector<std::string> scene_paths;
+        //! map of sub-scenes (.json)
         std::unordered_map<SceneId, std::string> scene_paths;
 
         //! array of file-paths, containing model-files (.gltf, .glb, .obj)
@@ -153,7 +152,7 @@ public:
 
     explicit PBRViewer(const crocore::Application::create_info_t &create_info);
 
-    void load_file(const std::string &path);
+    void load_file(const std::string &path, bool clear);
 
     bool parse_override_settings(int argc, char *argv[]);
 
@@ -198,7 +197,7 @@ private:
 
     static std::optional<scene_data_t> load_scene_data(const std::filesystem::path &path = "scene.json");
 
-    void build_scene(const std::optional<scene_data_t> &scene_data);
+    void build_scene(const std::optional<scene_data_t> &scene_data, bool import = false);
 
     struct overlay_assets_t
     {

--- a/projects/pbr_viewer/pbr_viewer.hpp
+++ b/projects/pbr_viewer/pbr_viewer.hpp
@@ -129,6 +129,9 @@ public:
 
     struct scene_data_t
     {
+        //! descriptive name for the scene
+        std::string name;
+
         //! array of file-paths, containing sub-scenes (.json)
         std::vector<std::string> scene_paths;
 
@@ -336,7 +339,8 @@ void serialize(Archive &ar, PBRViewer::scene_camera_t &camera)
 template<class Archive>
 void serialize(Archive &ar, PBRViewer::scene_data_t &scene_data)
 {
-    ar(cereal::make_optional_nvp("environment_path", scene_data.environment_path),
+    ar(cereal::make_optional_nvp("name", scene_data.name),
+       cereal::make_optional_nvp("environment_path", scene_data.environment_path),
        cereal::make_optional_nvp("scene_paths", scene_data.scene_paths),
        cereal::make_nvp("model_paths", scene_data.model_paths), cereal::make_nvp("nodes", scene_data.nodes),
        cereal::make_nvp("scene_roots", scene_data.scene_roots), cereal::make_nvp("cameras", scene_data.cameras),

--- a/projects/pbr_viewer/pbr_viewer_load_store.cpp
+++ b/projects/pbr_viewer/pbr_viewer_load_store.cpp
@@ -552,14 +552,17 @@ void PBRViewer::build_scene(const std::optional<scene_data_t> &scene_data_in, bo
         };
 
         auto done_cb = [this, scene_assets = std::move(scene_assets), create_root_object, clear_scene]() mutable {
+            // root nodes for all (sub-)scenes
             std::vector<vierkant::Object3DPtr> root_objects(scene_assets.size());
-            std::unordered_map<SceneId, vierkant::Object3DPtr> scene_map;
+
+            // map scene-ids to their root-objects
+            std::unordered_map<SceneId, vierkant::Object3DPtr> scene_root_map;
 
             for(uint32_t i = 0; i < scene_assets.size(); ++i)
             {
                 root_objects[i] = create_root_object(scene_assets[i].scene_data, scene_assets[i].meshes,
                                                      m_scene->registry(), scene_assets[i].objects);
-                scene_map[scene_assets[i].scene_id] = root_objects[i];
+                scene_root_map[scene_assets[i].scene_id] = root_objects[i];
                 auto &cmp = root_objects[i]->add_component<object_flags_component_t>();
                 cmp.scene_id = scene_assets[i].scene_id;
             }
@@ -573,8 +576,8 @@ void PBRViewer::build_scene(const std::optional<scene_data_t> &scene_data_in, bo
 
                     if(node.scene_id)
                     {
-                        assert(scene_map.contains(*node.scene_id));
-                        auto children = scene_map[*node.scene_id]->children;
+                        assert(scene_root_map.contains(*node.scene_id));
+                        auto children = scene_root_map[*node.scene_id]->children;
                         for(const auto &child: children) { scene_asset.objects[j]->add_child(child); }
 
                         // flag object to contain a sub-scene

--- a/projects/pbr_viewer/pbr_viewer_load_store.cpp
+++ b/projects/pbr_viewer/pbr_viewer_load_store.cpp
@@ -437,13 +437,21 @@ void PBRViewer::build_scene(const std::optional<scene_data_t> &scene_data_in, bo
                     }
                 }
             }
+            std::unordered_map<std::string, vierkant::MeshPtr> mesh_cache;
 
             // load meshes for scene and sub-scenes
             for(auto &asset: scene_assets)
             {
                 for(const auto &p: asset.scene_data.model_paths)
                 {
-                    auto mesh = load_mesh(p);
+                    vierkant::MeshPtr mesh;
+                    auto cache_it = mesh_cache.find(p);
+                    if(cache_it != mesh_cache.end()) { mesh = cache_it->second; }
+                    else
+                    {
+                        mesh = load_mesh(p);
+                        mesh_cache[p] = mesh;
+                    }
 
                     if(mesh)
                     {


### PR DESCRIPTION
get fucked openUSD, here we go!

getting serious now and really just need the basic divide&conquer magic to build more complex scenes.
existing alternatives quickly bloat the whole project like there's no tomorrow.
I end up extending both scope and lifetime of my coughed up "temporary" solution to scene-serialization,
because trying to avoid bloat and it's ever only going to be a 80/20 mix of stuff I actually need.

this PR adds the option to reference sub-scenes by UUID/path from other scene-files.
it's not much, but allows for far more complex scene-composition workflows and was a 
long-standing requirement to advance with more complex/rich content rendering.
 